### PR TITLE
removed a literal comparison pitfall case

### DIFF
--- a/audio.py
+++ b/audio.py
@@ -304,9 +304,9 @@ def dynamic_range_compression(db, threshold, ratio, method='downward'):
     :param method: Downward or upward.
     :return: Range compressed dB-scaled magnitudes
     """
-    if method is 'downward':
+    if method == 'downward':
         db[db > threshold] = (db[db > threshold] - threshold) / ratio + threshold
-    elif method is 'upward':
+    elif method == 'upward':
         db[db < threshold] = threshold - ((threshold - db[db < threshold]) / ratio)
     return db
 


### PR DESCRIPTION
**The problem**
In Python when comparing to non-singleton values, it advised to use the operator '==' instead of 'is'.
By doing otherwise, we may fall into the a code pitfall which can be detected by pylint under the identification of R0123 literal-comparison https://vald-phoenix.github.io/pylint-errors/plerr/errors/basic/R0123.html

**The solution**
Refactored the comparisons on literals