### PR TITLE
Add tensorflow v2 compatibility and requirements update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ outputs
 __*
 hparams
 tools
+venv
+.vscode

--- a/README.md
+++ b/README.md
@@ -54,10 +54,10 @@ Net2 contains Net1 as a sub-network.
 
 ## Implementations
 ### Requirements
-* python 2.7
-* tensorflow >= 1.1
-* numpy >= 1.11.1
-* librosa == 0.5.1
+* python 3.3+
+* tensorflow >= 1.8
+* tensorpack == 0.11
+* librosa == 0.6.3
 
 ### Settings
 * sample rate: 16,000Hz

--- a/colab-requirements.txt
+++ b/colab-requirements.txt
@@ -1,4 +1,5 @@
-tensorflow-gpu >= 1.8
+tensorflow-gpu == 2.4
+tensorflow == 2.4
 tensorpack == 0.11
 librosa == 0.6.3
 numba == 0.48

--- a/data_load.py
+++ b/data_load.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-# /usr/bin/python2
-
 import glob
 import random
 
@@ -8,7 +5,8 @@ import librosa
 import numpy as np
 from tensorpack.dataflow.base import RNGDataFlow
 from tensorpack.dataflow.common import BatchData
-from tensorpack.dataflow import PrefetchData
+from tensorpack.dataflow.parallel import MultiProcessRunner
+
 from audio import read_wav, preemphasis, amp2db
 from hparam import hparam as hp
 from utils import normalize_0_1
@@ -23,21 +21,21 @@ class DataFlow(RNGDataFlow):
     def __call__(self, n_prefetch=1000, n_thread=1):
         df = self
         df = BatchData(df, self.batch_size)
-        df = PrefetchData(df, n_prefetch, n_thread)
+        df = MultiProcessRunner(df, n_prefetch, n_thread)
         return df
 
 
 class Net1DataFlow(DataFlow):
 
-    def get_data(self):
+    def __iter__(self):
         while True:
             wav_file = random.choice(self.wav_files)
-            yield get_mfccs_and_phones(wav_file=wav_file)
+            yield get_mfccs_and_phones(wav_file)
 
 
 class Net2DataFlow(DataFlow):
 
-    def get_data(self):
+    def __iter__(self):
         while True:
             wav_file = random.choice(self.wav_files)
             yield get_mfccs_and_spectrogram(wav_file)

--- a/docker/pip-requirements.txt
+++ b/docker/pip-requirements.txt
@@ -1,9 +1,9 @@
-tensorflow-gpu >= 1.1
-numpy >= 1.11.1
-librosa == 0.5.1
-tensorpack == 0.8.0
+tensorflow-gpu >= 1.8
+tensorpack == 0.11
+librosa == 0.6.3
+numba == 0.48
 pyyaml
 soundfile
 pydub
-git+https://github.com/wookayin/tensorflow-plot.git@master
 tqdm
+git+https://github.com/wookayin/tensorflow-plot.git@master

--- a/eval1.py
+++ b/eval1.py
@@ -1,19 +1,14 @@
-# -*- coding: utf-8 -*-
-# /usr/bin/python2
-
-from __future__ import print_function
-
 import argparse
 
-import tensorflow as tf
+from tensorpack.compat import is_tfv2, tfv1 as tf
+from tensorpack.predict.base import OfflinePredictor
+from tensorpack.predict.config import PredictConfig
+from tensorpack.tfutils.sessinit import SaverRestore
 
 from data_load import Net1DataFlow, phns, load_vocab
 from hparam import hparam as hp
 from models import Net1
 from utils import plot_confusion_matrix
-from tensorpack.predict.config import PredictConfig
-from tensorpack.predict.base import OfflinePredictor
-from tensorpack.tfutils.sessinit import SaverRestore
 
 
 def get_eval_input_names():
@@ -25,6 +20,9 @@ def get_eval_output_names():
 
 
 def eval(logdir):
+    if is_tfv2(): 
+        tf.disable_v2_behavior()
+
     # Load graph
     model = Net1()
 
@@ -41,8 +39,7 @@ def eval(logdir):
         pred_conf.session_init = SaverRestore(ckpt)
     predictor = OfflinePredictor(pred_conf)
 
-    x_mfccs, y_ppgs = next(df().get_data())
-    y_ppg_1d, pred_ppg_1d, summ_loss, summ_acc = predictor(x_mfccs, y_ppgs)
+    y_ppg_1d, pred_ppg_1d, summ_loss, summ_acc = predictor(*next(df().ds.get_data()))
 
     # plot confusion matrix
     _, idx2phn = load_vocab()

--- a/hparam.py
+++ b/hparam.py
@@ -1,12 +1,9 @@
-# -*- coding: utf-8 -*-
-#!/usr/bin/env python
-
 import yaml
 
 
 def load_hparam(filename):
     stream = open(filename, 'r')
-    docs = yaml.load_all(stream)
+    docs = yaml.load_all(stream,  yaml.Loader)
     hparam_dict = dict()
     for doc in docs:
         for k, v in doc.items():

--- a/modules.py
+++ b/modules.py
@@ -1,9 +1,4 @@
-# -*- coding: utf-8 -*-
-#/usr/bin/python2
-
-from __future__ import print_function
-
-import tensorflow as tf
+from tensorpack.compat import tfv1 as tf
 
 
 def embed(inputs, vocab_size, num_units, zero_pad=True, scope="embedding", reuse=None):
@@ -213,9 +208,9 @@ def gru(inputs, num_units=None, bidirection=False, seqlens=None, scope="gru", re
         if num_units is None:
             num_units = inputs.get_shape().as_list[-1]
             
-        cell = tf.contrib.rnn.GRUCell(num_units)  
+        cell = tf.nn.rnn_cell.GRUCell(num_units)  
         if bidirection: 
-            cell_bw = tf.contrib.rnn.GRUCell(num_units)
+            cell_bw = tf.nn.rnn_cell.GRUCell(num_units)
             outputs, _ = tf.nn.bidirectional_dynamic_rnn(cell, cell_bw, inputs, 
                                                          sequence_length=seqlens,
                                                          dtype=tf.float32)
@@ -250,7 +245,7 @@ def attention_decoder(inputs, memory, seqlens=None, num_units=None, scope="atten
                                                                    memory_sequence_length=seqlens, 
                                                                    normalize=True,
                                                                    probability_fn=tf.nn.softmax)
-        decoder_cell = tf.contrib.rnn.GRUCell(num_units)
+        decoder_cell = tf.nn.rnn_cell.GRUCell(num_units)
         cell_with_attention = tf.contrib.seq2seq.AttentionWrapper(decoder_cell, attention_mechanism, num_units)
         outputs, _ = tf.nn.dynamic_rnn(cell_with_attention, inputs, 
                                        dtype=tf.float32) #( N, T', 16)

--- a/tensorpack_extension.py
+++ b/tensorpack_extension.py
@@ -1,11 +1,9 @@
-# -*- coding: utf-8 -*-
-#!/usr/bin/env python
-
 import re
-from tensorpack.utils import logger
-from tensorpack.tfutils.gradproc import GradientProcessor
+
 from tensorpack.callbacks.monitor import JSONWriter
-import tensorflow as tf
+from tensorpack.compat import tfv1 as tf
+from tensorpack.tfutils.gradproc import GradientProcessor
+from tensorpack.utils import logger
 
 
 # class AudioWriter(TrainingMonitor):

--- a/train1.py
+++ b/train1.py
@@ -1,23 +1,17 @@
-# -*- coding: utf-8 -*-
-# /usr/bin/python2
-
-from __future__ import print_function
-
 import argparse
-import multiprocessing
 import os
 
 from tensorpack.callbacks.saver import ModelSaver
+from tensorpack.compat import tfv1 as tf
+from tensorpack.input_source.input_source import QueueInput
 from tensorpack.tfutils.sessinit import SaverRestore
-from tensorpack.train.interface import TrainConfig
-from tensorpack.train.interface import launch_train_with_config
+from tensorpack.train.interface import launch_train_with_config, TrainConfig
 from tensorpack.train.trainers import SyncMultiGPUTrainerReplicated
 from tensorpack.utils import logger
-from tensorpack.input_source.input_source import QueueInput
+
 from data_load import Net1DataFlow
 from hparam import hparam as hp
 from models import Net1
-import tensorflow as tf
 
 
 def train(args, logdir):
@@ -31,10 +25,12 @@ def train(args, logdir):
     # set logger for event and model saver
     logger.set_logger_dir(logdir)
 
-    session_conf = tf.ConfigProto(
+    session_config = tf.ConfigProto(
+        allow_soft_placement=True,
         gpu_options=tf.GPUOptions(
             allow_growth=True,
-        ),)
+        ),
+    )
 
     train_conf = TrainConfig(
         model=model,
@@ -45,7 +41,7 @@ def train(args, logdir):
         ],
         max_epoch=hp.train1.num_epochs,
         steps_per_epoch=hp.train1.steps_per_epoch,
-        # session_config=session_conf
+        session_config=session_config
     )
     ckpt = '{}/{}'.format(logdir, args.ckpt) if args.ckpt else tf.train.latest_checkpoint(logdir)
     if ckpt:
@@ -73,7 +69,7 @@ if __name__ == '__main__':
     hp.set_hparam_yaml(args.case)
     logdir_train1 = '{}/train1'.format(hp.logdir)
 
-    print('case: {}, logdir: {}'.format(args.case1, args.case, logdir_train1))
+    print('case: {}, logdir: {}'.format(args.case, logdir_train1))
 
     train(args, logdir=logdir_train1)
 


### PR DESCRIPTION
Hi @andabi,
I had some problems running the project on the current dependencies, so I decided to make it compatible with current versions of tensorpack and tensorflow.
The latest tensorpack version (0.11) offers basic tf2 compatibility, so I fixed tf imports and made some changes to make it work with 0.11 version of tensorpack. Using python 2 is now deprecated, also latest tensorpack requires python 3.3+, so I changed requirements there as well.
I tested these changes on google colab with GPU and it works fine.
Consider merging.